### PR TITLE
Stop downloading the app asynchronously

### DIFF
--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -376,12 +376,11 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 		app.Environment = &vv
 	}
 
-	// Download application binary / source asynchronously
-	prepare := make(chan error)
-	go func() {
-		appPath, err = prepareApp(app, d, session.Log)
-		prepare <- err
-	}()
+	// Download application binary
+	appPath, err = prepareApp(app, d, session.Log)
+	if err != nil {
+		return
+	}
 
 	if v, hasRouteConfig = d.GetOk("route"); hasRouteConfig {
 
@@ -418,11 +417,6 @@ func resourceAppCreate(d *schema.ResourceData, meta interface{}) (err error) {
 		}
 	}()
 
-	// Upload application binary / source
-	// asynchronously once download has completed
-	if err = <-prepare; err != nil {
-		return
-	}
 	upload := make(chan error)
 	go func() {
 		err = am.UploadApp(app, appPath, addContent)


### PR DESCRIPTION
The problem is that the schema.ResourceData is not thread safe, even
for concurrent reads, due to internal memoization during reads.  The
result was that app creation would sometimes fail mysteriously with an
"unexpected EOF" error due to the provider process crashing due to
either concurrent map writes or read/write.