### PR TITLE
update app_read to official manner

### DIFF
--- a/bin/terraform-provider-cf_darwin_amd64
+++ b/bin/terraform-provider-cf_darwin_amd64
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:849098221b150c39f8c2338f5be8d7f55fb0ff7853a5857387af8739b1e21a22
-size 40985468
+oid sha256:93cd5c1da134c711a9f40049f4f4e218e80cad1f22cd4fe46af21e717b002aa0
+size 41482924

--- a/bin/terraform-provider-cf_linux_amd64
+++ b/bin/terraform-provider-cf_linux_amd64
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0a6fe18d279ca0219dd7c5d4ff7c953919c6c9195caaaba2a2dd27cab3f371db
-size 41159020
+oid sha256:80a11b090669b8896cc758678346ead4d677a85bdaab9d50c9d22ad1cdc6d5a9
+size 41735557

--- a/cloudfoundry/resource_cf_app.go
+++ b/cloudfoundry/resource_cf_app.go
@@ -582,7 +582,7 @@ func resourceAppRead(d *schema.ResourceData, meta interface{}) (err error) {
 	var app cfapi.CCApp
 	if app, err = am.ReadApp(id); err != nil {
 		if strings.Contains(err.Error(), "status code: 404") {
-			d.MarkNewResource()
+			d.SetId("")
 			err = nil
 		}
 	} else {


### PR DESCRIPTION
This pr is created to fix the error that when the app is missing, the provider take the changes (not completed yet) to tfstate.

Now when the app is missing, it will delete the missing app from .tfstate and ask for creating an new app.